### PR TITLE
Handle empty mood data gracefully

### DIFF
--- a/STOPITERATION_FIX.md
+++ b/STOPITERATION_FIX.md
@@ -1,0 +1,138 @@
+# StopIteration Error Fix for mood_checker_tkinter.py
+
+## Problem
+The error occurs in the `has_mood_saved_today()` function at line 94 when trying to skip the CSV header:
+
+```python
+next(reader)  # Skip header
+```
+
+This raises `StopIteration` when the CSV file is empty or contains only a header row.
+
+## Root Cause
+The `next()` function raises `StopIteration` when there are no more items to iterate over. In CSV files with only headers or empty files, calling `next(reader)` after creating the reader will immediately hit this exception.
+
+## Solution
+Replace the problematic `has_mood_saved_today()` function with this safe version:
+
+```python
+def has_mood_saved_today():
+    """Check if user has already saved mood today - with proper error handling"""
+    username = getpass.getuser()
+    today = date.today().isoformat()
+    
+    try:
+        with open(MOOD_FILE, 'r', newline='') as f:
+            reader = csv.reader(f)
+            try:
+                # Try to skip header, but handle empty file case
+                next(reader)
+            except StopIteration:
+                # File is empty or has no content after header
+                return False
+            
+            for row in reader:
+                if len(row) >= 2:  # Ensure we have at least timestamp and username
+                    timestamp, file_username = row[0], row[1]
+                    if file_username == username and timestamp.startswith(today):
+                        return True
+    except FileNotFoundError:
+        # File doesn't exist, so no mood saved today
+        return False
+    except Exception as e:
+        print(f"Error reading mood file: {e}")
+        return False
+    
+    return False
+```
+
+## Key Changes Made
+
+1. **Added StopIteration handling**: Wrapped `next(reader)` in a try-except block to catch the StopIteration exception
+2. **Graceful empty file handling**: When StopIteration occurs, return False (no mood saved today)
+3. **Enhanced error handling**: Added FileNotFoundError and general exception handling
+4. **Improved robustness**: Added length checks for CSV rows to prevent index errors
+
+## Alternative Approaches
+
+### Approach 1: Read all rows first
+```python
+def has_mood_saved_today():
+    username = getpass.getuser()
+    today = date.today().isoformat()
+    
+    try:
+        with open(MOOD_FILE, 'r', newline='') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+            
+            # Skip header if exists
+            data_rows = rows[1:] if len(rows) > 1 else []
+            
+            for row in data_rows:
+                if len(row) >= 2:
+                    timestamp, file_username = row[0], row[1]
+                    if file_username == username and timestamp.startswith(today):
+                        return True
+    except FileNotFoundError:
+        return False
+    except Exception as e:
+        print(f"Error reading mood file: {e}")
+        return False
+    
+    return False
+```
+
+### Approach 2: Check file size first
+```python
+def has_mood_saved_today():
+    if not os.path.exists(MOOD_FILE):
+        return False
+    
+    # Check if file is empty or very small
+    if os.path.getsize(MOOD_FILE) <= 50:  # Arbitrary small size
+        return False
+    
+    username = getpass.getuser()
+    today = date.today().isoformat()
+    
+    try:
+        with open(MOOD_FILE, 'r', newline='') as f:
+            reader = csv.reader(f)
+            next(reader, None)  # Use default value to avoid StopIteration
+            
+            for row in reader:
+                if len(row) >= 2:
+                    timestamp, file_username = row[0], row[1]
+                    if file_username == username and timestamp.startswith(today):
+                        return True
+    except Exception as e:
+        print(f"Error reading mood file: {e}")
+        return False
+    
+    return False
+```
+
+## How to Apply the Fix
+
+1. **Locate the problematic function**: Find the `has_mood_saved_today()` function in your `mood_checker_tkinter.py` file (around line 90-94)
+
+2. **Replace the entire function**: Replace the existing function with the safe version provided above
+
+3. **Test the fix**: Run your application to ensure the StopIteration error is resolved
+
+## Verification
+
+After applying the fix, your application should:
+- ✅ Handle empty CSV files gracefully
+- ✅ Handle CSV files with only headers
+- ✅ Continue to work correctly with existing data
+- ✅ Not crash with StopIteration errors
+
+## Files Created for Reference
+
+- `fix_stopiteration.py`: Demonstration script showing the problem and solution
+- `mood_checker_tkinter_fixed.py`: Complete fixed version of the mood checker application
+- `STOPITERATION_FIX.md`: This documentation file
+
+The fix ensures your mood checking application will work reliably regardless of the CSV file state.


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Documents a fix for the `StopIteration` error in `has_mood_saved_today()` by handling empty CSV files.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `StopIteration` error occurred when `next(reader)` was called on an empty CSV file (or one with only a header), as it didn't gracefully handle the absence of data rows. The provided fix in `STOPITERATION_FIX.md` wraps this call in a try-except block, ensuring the application continues to function without crashing when the mood data file is empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4f09de2-47f1-44dd-ad26-2759603cea6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a4f09de2-47f1-44dd-ad26-2759603cea6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>